### PR TITLE
add marketwatch data and run time display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bigbeta/config.py

--- a/bigbeta/stocks/routes.py
+++ b/bigbeta/stocks/routes.py
@@ -6,18 +6,35 @@ from flask import render_template, request, redirect, url_for, Blueprint
 from bigbeta import db, bcrypt
 from bigbeta.models import Stocks
 from bigbeta.stocks.utils import build_watchlist
-# from bigbeta.users.forms import RegistrationForm
+from datetime import datetime
+from pytz import timezone
 
 
 stocks = Blueprint('stocks', __name__)
 
 
 @stocks.route("/stocks")
-def premarket_gainers():
+def top_gainers():
     """
     Stocks Watchlist Page - One Day Watchlist
     """
 
-    oneday_gainers = build_watchlist(rank_type='1d', wl_cnt=15)
+    tz = timezone("US/Eastern")
+    rn = datetime.now(tz).time()
+    mkt_opn = datetime.strptime("08:00:00", "%H:%M:%S").time()
+    mkt_cls = datetime.strptime("16:00:00", "%H:%M:%S").time()
+    if rn < mkt_opn:
+        rank_type = "preMarket"
+    elif rn > mkt_opn and rn < mkt_cls:
+        rank_type = "1d"
+    elif rn > mkt_cls:
+        rank_type = "afterMarket"
 
-    return render_template('stocks.html', oneday_gainers=oneday_gainers)
+    oneday_gainers = build_watchlist(rank_type=rank_type)
+    run_time_display = rn.strftime("%H:%M:%S")
+
+    return render_template(
+        'stocks.html',
+        oneday_gainers=oneday_gainers,
+        run_time_display=run_time_display,
+        rank_type=rank_type)

--- a/bigbeta/templates/stocks.html
+++ b/bigbeta/templates/stocks.html
@@ -3,7 +3,7 @@
 {% block content %}
     <head><meta http-equiv="refresh" content="300"></head>
     <h1>Watchlists</h1>
-    <p>Watchlists Here, Getchur Watchlists here!</p>
+    <h4>Ran for {{ rank_type }} at: {{ run_time_display }} </h4>
 
     <table id="data" class="table table-striped">
     <thead>


### PR DESCRIPTION
Adds NYSE short interest data by scraping marketwatch pages when WeBull an't access that data from NASDAQ. 
Also adds aftermarket and premarket runs based on time of day and displays which watchlist was run and the last time it was run. 