### PR TITLE
remove climbing refs. error handling

### DIFF
--- a/bigbeta/__init__.py
+++ b/bigbeta/__init__.py
@@ -64,7 +64,7 @@ def create_app(config_class=Config):
 def create_app_context(confif_class=Config):
     """
     Creates app context for use by cron jobs or other external services.
-        Using the above create_app function will result in circular import errors 
+        Using the above create_app function will result in circular import errors
     """
     app = Flask(__name__)
     app.config.from_object(Config)

--- a/bigbeta/main/routes.py
+++ b/bigbeta/main/routes.py
@@ -23,3 +23,12 @@ def home():
 @main.route("/about")
 def about():
     return render_template('about.html', title='About')
+
+
+@main.route("/stock_not_found")
+def custom_error__stock_not_found():
+    """
+    If a stock is not found in a user's search, return this page
+    """
+
+    return render_template("custom_errors__stock_not_found.html")

--- a/bigbeta/models.py
+++ b/bigbeta/models.py
@@ -47,7 +47,8 @@ class User(db.Model, UserMixin):
 
 class Post(db.Model):
     """
-    This is probably comparable to a climb class
+    Class for user posts.
+    Not totally necessary for current state of site 
     """
 
     id = db.Column(db.Integer, primary_key=True)

--- a/bigbeta/stocks/routes.py
+++ b/bigbeta/stocks/routes.py
@@ -7,7 +7,7 @@ import json
 from datetime import datetime
 from pytz import timezone
 
-from flask import render_template, request, redirect, url_for, Blueprint
+from flask import render_template, request, redirect, url_for, Blueprint, flash
 from flask_login import current_user, login_required
 
 from bigbeta import db, bcrypt
@@ -68,9 +68,15 @@ def top_gainers():
         #   Then add the updated data of the searched stock to the list
         #   Then write the new list to the user search file, which will be loaded on redirect
         remove_from_watchlist(search_form.tckr_input.data)
+        # Load current list
         with open(f"{cur_wd}/bigbeta/stocks/user_search/{current_user.id}_searches.json", "r") as f:
             updated_search_list = json.load(f)
-        updated_search_list.append(search_ticker(search_form.tckr_input.data))
+        # Get data on searched ticker and add it to list
+        try:
+            updated_search_list.append(search_ticker(search_form.tckr_input.data))
+        except:
+            flash("Ticker not found - Please check spelling", "danger")
+        # Save updated list and load the page with it
         with open(f"{cur_wd}/bigbeta/stocks/user_search/{current_user.id}_searches.json", "w") as f:
             json.dump(updated_search_list, f)
         return redirect(url_for("stocks.top_gainers"))

--- a/bigbeta/templates/custom_errors__stock_not_found.html
+++ b/bigbeta/templates/custom_errors__stock_not_found.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+{% block content %}
+    <div class="content-section">
+        <h1>404 Error - Couldn't find that ticker</h1>
+        <p>Did you type it in correctly?</p>
+        <p>Fun fact: Australia is wider than the moon!</p>
+        <a class="ml-2" href="{{ url_for('stocks.top_gainers') }}">Return to Top Gainers Page</a>
+    </div>
+{% endblock content %}

--- a/bigbeta/templates/errors/403.html
+++ b/bigbeta/templates/errors/403.html
@@ -2,6 +2,6 @@
 {% block content %}
     <div class="content-section">
         <h1>You don't have permission to do that.</h1>
-        <p>Like bolting a crack!</p>
+        <p>Like bolting a crack! (It's a climbing reference)</p>
     </div>
 {% endblock content %}

--- a/bigbeta/templates/errors/404.html
+++ b/bigbeta/templates/errors/404.html
@@ -2,6 +2,6 @@
 {% block content %}
     <div class="content-section">
         <h1>404 Error - Page doesn't exist!</h1>
-        <p>Did you get lost on the way to the crag?</p>
+        <!-- <p>Did you get lost on the way to the crag?</p> -->
     </div>
 {% endblock content %}

--- a/bigbeta/templates/errors/500.html
+++ b/bigbeta/templates/errors/500.html
@@ -2,6 +2,7 @@
 {% block content %}
     <div class="content-section">
         <h1>500 Error - Something is wrong</h1>
-        <p>Not sure what the problem is, good thing you're at a no-hands rest!</p>
+        <p>I'm just one developer and I haven't yet planned for this error :(</p>
+        <p>I'll figure it out as soon as I can!</p>
     </div>
 {% endblock content %}

--- a/bigbeta/users/forms.py
+++ b/bigbeta/users/forms.py
@@ -23,7 +23,7 @@ class RegistrationForm(FlaskForm):
     confirm_password = PasswordField('Confirm Password',
                                      validators=[DataRequired(), EqualTo('password')])
     remember = BooleanField('Remember Me')
-    submit = SubmitField('Get Climbing!')
+    submit = SubmitField('Sign Up!')
 
 
     def validate_username(self, username):
@@ -48,7 +48,7 @@ class LoginForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     password = PasswordField('Password', validators=[DataRequired()])
     remember = BooleanField('Remember Me')
-    submit = SubmitField('Get Climbing!')
+    submit = SubmitField('Login')
 
 
 class UpdateAccountForm(FlaskForm):


### PR DESCRIPTION
Removes references to climbing since this is now a finance app.
Adjusts error handling on bad searches. (This was semi-related to climbing refs because the errors were climbing references.)
- `__init__.py`: Added a space apparently 
- `main/routes.py`: Adds a function for rendering a custom error page template 
- `stocks/routes.py`: Flash error message instead of error redirect (500) on a bad search
- `templates/*`: Hard coding, html crap
- `users/forms.py`: Remove climbing refs from UI buttons